### PR TITLE
Fix lack of colon regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,10 @@ exports.validate = (platform, socialMediaUrl) =>  {
     const regexMap = {
         facebook:
 		/^(https?:\/\/)?(?:www\.)?(?:facebook|fb|m\.facebook)\.(?:com|me)\/(?:(?:\w)*#!\/)?(?:pages\/)?(?:[\w-]*\/)*([\w\-]+\.?)(?:\/)?/i,
-	    instagram: /(http(?:s)?:\/\/)?(?:www\.)?instagram\.com\/([a-zA-Z0-9_]+)/,
-	    twitter: /(http(?:s)?:\/\/)?(?:www\.)?twitter\.com\/([a-zA-Z0-9_]+)/,
-
+	    instagram: /^(http(s)?:\/\/)?(?:www\.)?instagram\.com\/([a-zA-Z0-9_]+)/,
+	    twitter: /^(http(s)?:\/\/)?(?:www\.)?twitter\.com\/([a-zA-Z0-9_]+)/,
 	    linkedin:
-		/^(http(s)?:\/\/)?([\w]+\.)?linkedin\.com\/(pub|in|profile|company)\/([a-zA-Z0-9_]+)/,
+      /^(http(s)?:\/\/)?([\w]+\.)?linkedin\.com\/(pub|in|profile|company)\/([a-zA-Z0-9_]+)/,
 	    emailaddress: /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/,
     }
     let isValid = false


### PR DESCRIPTION
## Changes
- Fix lack of colon regex

For twitter and instagram, urls such as the following were passing when they should not have been:
- [https//twitter.com/HelloAlice](https://regexr.com/6601a)
- [https//www.instagram.com/helloalice_com/](https://regexr.com/65vph)