### PR TITLE
Added support for twitter/x (Renamed)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,22 +1,23 @@
-exports.validate = (platform, socialMediaUrl) =>  {
-    platform = platform.toLowerCase()
-    const regexMap = {
-        facebook:
-		/^(https?:\/\/)?(?:www\.)?(?:facebook|fb|m\.facebook)\.(?:com|me)\/(?:(?:\w)*#!\/)?(?:pages\/)?(?:[\w-]*\/)*([\w\-]+\.?)(?:\/)?/i,
-	    instagram: /^(http(s)?:\/\/)?(?:www\.)?instagram\.com\/([a-zA-Z0-9_]+)/,
-	    twitter: /^(http(s)?:\/\/)?(?:www\.)?twitter\.com\/([a-zA-Z0-9_]+)/,
-	    linkedin:
+exports.validate = (platform, socialMediaUrl) => {
+  platform = platform.toLowerCase();
+  const regexMap = {
+    facebook:
+      /^(https?:\/\/)?(?:www\.)?(?:facebook|fb|m\.facebook)\.(?:com|me)\/(?:(?:\w)*#!\/)?(?:pages\/)?(?:[\w-]*\/)*([\w\-]+\.?)(?:\/)?/i,
+    instagram: /^(http(s)?:\/\/)?(?:www\.)?instagram\.com\/([a-zA-Z0-9_]+)/,
+    twitter: /^(http(s)?:\/\/)?(?:www\.)?(twitter|x)\.com\/([a-zA-Z0-9_]+)/,
+    x: /^(http(s)?:\/\/)?(?:www\.)?(twitter|x)\.com\/([a-zA-Z0-9_]+)/,
+    linkedin:
       /^(http(s)?:\/\/)?([\w]+\.)?linkedin\.com\/(pub|in|profile|company)\/([a-zA-Z0-9_]+)/,
-	    emailaddress: /\w+([-+.']\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*/,
-        website: /^((https?):\/\/)?([w|W]{3}\.)+[a-zA-Z0-9\-\.]{3,}\.[a-zA-Z]{2,}(\.[a-zA-Z]{2,})?$/
+    emailaddress: /\w+([-+.']\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*/,
+    website:
+      /^((https?):\/\/)?([w|W]{3}\.)+[a-zA-Z0-9\-\.]{3,}\.[a-zA-Z]{2,}(\.[a-zA-Z]{2,})?$/,
+  };
+  let isValid = false;
+  if (regexMap[platform]) {
+    if (regexMap[platform].test(socialMediaUrl)) {
+      isValid = true;
     }
-    let isValid = false
-    if (regexMap[platform]){
-        if (regexMap[platform].test(socialMediaUrl)) {
-            isValid = true
-        }
-    }
+  }
 
-    return isValid
-
-}
+  return isValid;
+};


### PR DESCRIPTION
Twitter was renamed to X, along with the change in its base domain/URL, and thus, it's necessary to support the new domain - `x.com`, along with keeping `twitter.com` for backward compatibility.